### PR TITLE
rpminspect: use env vars

### DIFF
--- a/rpminspect.fmf
+++ b/rpminspect.fmf
@@ -16,8 +16,11 @@ prepare:
             echo "No build specified"
             exit 1
         fi
+        dnf -y install dnf-plugins-core
+        dnf -y copr enable dcantrell/rpminspect
         dnf -y install rpminspect
 
 execute:
     how: shell
-    script: rpminspect $ARGS $BUILD
+    script:
+        - rpminspect $ARGS $BUILD


### PR DESCRIPTION
Maybe we could avoid passing whole script and this is more nice ...

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>